### PR TITLE
Feat: retry rpc call if it errors in connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,13 @@ module.exports = makePaymentChannelPlugin({
     // query peer until they have a channel id
     while (true) {
       debug('querying peer for their payment channel id')
-      self.incomingPaymentChannelId = await ctx.rpc.call('ripple_channel_id', self.prefix, [])
+      try {
+        self.incomingPaymentChannelId = await ctx.rpc.call('ripple_channel_id', self.prefix, [])
+      } catch (e) {
+        debug('rpc error getting payment channel id: "' + e.message + '"; retrying in 5000')
+        await sleep(5000)
+        continue
+      }
       if (self.incomingPaymentChannelId) {
         debug('got peer payment channel id:', self.incomingPaymentChannelId)
         break


### PR DESCRIPTION
If the peer has a connection refused error or is temporarily offline, it will cause the connection process to crash. This can pose some serious problems when two peers try to start, because one will always be started earlier than the other and then crash. By making sure all RPC errors are still retried, it becomes possible to start two instances and have them sync up.