### PR TITLE
Safer semantics around channel close

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const crypto = require('crypto')
 const bignum = require('bignum') // required in order to convert to buffer
 const BigNumber = require('bignumber.js')
 const assert = require('assert')
-const moment = require('moment')
 const { ChannelWatcher } = require('ilp-plugin-xrp-paychan-shared')
 
 // constants
@@ -143,11 +142,11 @@ async function reloadIncomingChannelDetails (ctx) {
   }
 
   if (incomingChan.cancelAfter) {
-    checkChannelExpiry(ctx, incomingChan.cancelAfter)
+    throw new Error('incoming channel should not have a hard expiry')
   }
 
   if (incomingChan.expiration) {
-    checkChannelExpiry(ctx, incomingChan.expiration)
+    throw new Error('incoming channel must not already be closing')
   }
 
   if (incomingChan.destination !== self.address) {
@@ -159,16 +158,6 @@ async function reloadIncomingChannelDetails (ctx) {
   self.watcher.watch(chanId)
   self.incomingPaymentChannelId = chanId
   self.incomingPaymentChannel = incomingChan
-}
-
-function checkChannelExpiry (ctx, expiry) {
-  const isAfter = moment().add(MIN_SETTLE_DELAY, 'seconds').isAfter(expiry)
-
-  if (isAfter) {
-    ctx.plugin.debug('incoming payment channel expires too soon. ' +
-        'Minimum expiry is ' + MIN_SETTLE_DELAY + ' seconds.')
-    throw new Error('incoming channel expires too soon')
-  }
 }
 
 async function fund (ctx, fundOpts) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bignum": "^0.12.5",
     "btp-packet": "^1.0.0",
     "ilp-plugin-payment-channel-framework": "^1.3.1",
+    "ilp-plugin-xrp-paychan-shared": "https://github.com/dappelt/ilp-plugin-xrp-paychan-shared.git",
     "moment": "^2.19.2",
     "ripple-lib": "^0.17.7",
     "tweetnacl": "^1.0.0",

--- a/test/channelSpec.js
+++ b/test/channelSpec.js
@@ -114,7 +114,8 @@ describe('channelSpec', function () {
 
       await this.plugin.connect()
 
-      expect(connectSpy).to.have.been.calledOnce
+      // called once by plugin, once by watcher
+      expect(connectSpy).to.have.been.calledTwice
       expect(prepareSpy).to.have.been.calledAfter(connectSpy).and
         .calledWith(this.opts.address)
       expect(signSpy).to.have.been.calledAfter(prepareSpy).and
@@ -267,22 +268,6 @@ describe('channelSpec', function () {
 
         return expect(this.plugin.connect()).to.be
           .rejectedWith('settle delay of incoming payment channel too low')
-      })
-
-      it('throws if cancelAfter is too soon', function () {
-        sinon.stub(this.pluginState.api, 'getPaymentChannel').onSecondCall()
-          .returns(this.cancelAfterTooSoon)
-
-        return expect(this.plugin.connect()).to.be
-          .rejectedWith('incoming channel expires too soon')
-      })
-
-      it('throws if expiration is too soon', function () {
-        sinon.stub(this.pluginState.api, 'getPaymentChannel').onSecondCall()
-          .returns(this.expirationTooSoon)
-
-        return expect(this.plugin.connect()).to.be
-          .rejectedWith('incoming channel expires too soon')
       })
 
       it('throws if destination address is not the plugin\'s', function () {


### PR DESCRIPTION
* uses ChannelWatcher from https://github.com/dappelt/ilp-plugin-xrp-paychan-shared
* if channel closes, call disconnect on the plugin (to stop transacting and submit last claim)
* if channel has cancelAfter or expiration at connect time, refuse to connect (previous behavior was to allow these fields so long as they were far enough in the future)