### PR TITLE
Feat: support scale of 9

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,12 @@ class PluginXrpPaychan extends PluginBtp {
     this._secret = opts.secret
     this._address = opts.address || deriveAddress(deriveKeypair(this._secret).publicKey)
 
+    if (typeof opts.currencyScale !== 'number' && opts.currencyScale !== undefined) {
+      throw new Error('opts.currencyScale must be a number if specified.' +
+        ' type=' + (typeof opts.currencyScale) +
+        ' value=' + opts.currencyScale)
+    }
+
     this._currencyScale = (typeof opts.currencyScale === 'number') ? opts.currencyScale : 6
 
     this._peerAddress = opts.peerAddress // TODO: try to get this over the paychan?

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -419,6 +419,24 @@ describe('Plugin XRP Paychan Symmetric', function () {
       }
     })
 
+    describe('with low scale', function () {
+      beforeEach(function () {
+        this.plugin._currencyScale = 2
+        this.plugin._outgoingClaim = {
+          amount: '9',
+          signature: '61626364656667'
+        }
+      })
+
+      it('should multiply base to get drops', async function () {
+        this.sinon.stub(this.plugin, '_call').resolves(null)
+
+        await this.plugin.sendMoney(2)
+
+        assert.deepEqual(this.encodeStub.getCall(0).args, [ '110000', 'my_channel_id' ])
+      })
+    })
+
     describe('with high scale', function () {
       beforeEach(function () {
         this.plugin._currencyScale = 9

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -247,6 +247,14 @@ describe('Plugin XRP Paychan Symmetric', function () {
           /peer is unable to accomodate our currencyScale; they are on an out of date version of this plugin/)
       })
 
+      it('should not throw an error if the peer doesn\'t support info but our scale is 6', async function () {
+        this.plugin._currencyScale = 6
+        this.sinon.stub(this.plugin, '_call')
+          .rejects(new Error('no ilp protocol on request'))
+
+        await this.plugin._reloadIncomingChannelDetails()
+      })
+
       it('should throw an error if the peer scale does not match ours', async function () {
         this.sinon.stub(this.plugin, '_call')
           .resolves({ protocolData: [{

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -174,6 +174,7 @@ describe('Plugin XRP Paychan Symmetric', function () {
     })
 
     it('should return if getPaymentChannel gives a rippled error', async function () {
+      this.sinon.stub(this.plugin, '_call').rejects(new Error('info protocol is not supported'))
       const stub = this.sinon.stub(this.plugin._api, 'getPaymentChannel')
         .callsFake(() => {
           throw new Error('there was an error!')
@@ -185,6 +186,7 @@ describe('Plugin XRP Paychan Symmetric', function () {
 
     it('should throw if settleDelay is too soon', async function () {
       this.channel.settleDelay = util.MIN_SETTLE_DELAY - 1
+      this.sinon.stub(this.plugin, '_call').rejects(new Error('info protocol is not supported'))
       this.sinon.stub(this.plugin._api, 'getPaymentChannel')
         .resolves(this.channel)
 
@@ -194,6 +196,7 @@ describe('Plugin XRP Paychan Symmetric', function () {
 
     it('should throw if cancelAfter is specified', async function () {
       this.channel.cancelAfter = Date.now() + 1000
+      this.sinon.stub(this.plugin, '_call').rejects(new Error('info protocol is not supported'))
       this.sinon.stub(this.plugin._api, 'getPaymentChannel')
         .resolves(this.channel)
 
@@ -203,6 +206,7 @@ describe('Plugin XRP Paychan Symmetric', function () {
 
     it('should throw if expiration is specified', async function () {
       this.channel.expiration = Date.now() + 1000
+      this.sinon.stub(this.plugin, '_call').rejects(new Error('info protocol is not supported'))
       this.sinon.stub(this.plugin._api, 'getPaymentChannel')
         .resolves(this.channel)
 
@@ -212,6 +216,7 @@ describe('Plugin XRP Paychan Symmetric', function () {
 
     it('should throw if destination does not match our account', async function () {
       this.channel.destination = this.plugin._peerAddress
+      this.sinon.stub(this.plugin, '_call').rejects(new Error('info protocol is not supported'))
       this.sinon.stub(this.plugin._api, 'getPaymentChannel')
         .resolves(this.channel)
 
@@ -220,6 +225,7 @@ describe('Plugin XRP Paychan Symmetric', function () {
     })
 
     it('should return if all details are ok', async function () {
+      this.sinon.stub(this.plugin, '_call').rejects(new Error('info protocol is not supported'))
       this.sinon.stub(this.plugin._api, 'getPaymentChannel')
         .resolves(this.channel)
 

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -73,6 +73,30 @@ describe('Plugin XRP Paychan Symmetric', function () {
     this.sinon.restore()
   })
 
+  describe('constructor', function () {
+    beforeEach(function () {
+      this.opts = {
+        xrpServer: 'wss://s.altnet.rippletest.net:51233',
+        secret: 'sahNtietWCRzmX7Z2Zy7Z3EsvFDjv',
+        address: 'ra3h9tzcipHTZCdQesMthfx4iBZNEEuHXG',
+        peerAddress: 'rKwCnwtM6et7BVaCZm97hbU8oXkoohReea',
+        _store: new Store()
+      }
+    })
+
+    it('should throw an error on non-number currencyScale', function () {
+      this.opts.currencyScale = 'foo'
+      assert.throws(() => new Plugin(this.opts),
+        /opts.currencyScale must be a number if specified/)
+    })
+
+    it('should not throw an error on number currencyScale', function () {
+      this.opts.currencyScale = 6
+      const plugin = new Plugin(this.opts)
+      assert.isOk(plugin)
+    })
+  })
+
   describe('_handleData', function () {
     it('should handle ilp data', async function () {
       let handled = false


### PR DESCRIPTION
Support a scale greater than that of XRP ledger. Amounts are simply rounded up in drops. Because the high-scale amounts are kept alongside claim signatures, though, the error is bounded at 1 drop.