### PR TITLE
Fix: safety around channel id

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ class PluginXrpPaychan extends PluginBtp {
       if (!this._incomingChannel) {
         this._incomingChannel = protocolMap.ripple_channel_id
         this._store.set('incoming_channel', this._incomingChannel)
+        await this._watcher.watch(this._incomingChannel)
       }
 
       await this._reloadIncomingChannelDetails()
@@ -136,6 +137,7 @@ class PluginXrpPaychan extends PluginBtp {
           .data
           .toString()
         this._store.set('incoming_channel', this._incomingChannel)
+        await this._watcher.watch(this._incomingChannel)
       } catch (err) { debug(err) }
 
       if (!this._incomingChannel) {
@@ -244,6 +246,10 @@ class PluginXrpPaychan extends PluginBtp {
     this._incomingClaim = JSON.parse(this._store.get('incoming_claim') || '{"amount":"0"}')
     this._outgoingClaim = JSON.parse(this._store.get('outgoing_claim') || '{"amount":"0"}')
     debug('loaded incoming claim:', this._incomingClaim)
+
+    if (this._incomingChannel) {
+      await this._watcher.watch(this._incomingChannel)
+    }
 
     if (!this._outgoingChannel) {
       debug('creating new payment channel')

--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ class PluginXrpPaychan extends PluginBtp {
     const { ilp, protocolMap } = this.protocolDataToIlpAndCustom(data)
 
     if (protocolMap.ripple_channel_id) {
-      this._incomingChannel = protocolMap.ripple_channel_id
+      if (!this._incomingChannel) {
+        this._incomingChannel = protocolMap.ripple_channel_id
+        this._store.set('incoming_channel', this._incomingChannel)
+      }
+
       await this._reloadIncomingChannelDetails()
 
       return [{
@@ -230,10 +234,12 @@ class PluginXrpPaychan extends PluginBtp {
     })
     debug('connected to rippled')
 
+    await this._store.load('incoming_channel')
     await this._store.load('outgoing_channel')
     await this._store.load('incoming_claim')
     await this._store.load('outgoing_claim')
 
+    this._incomingChannel = this._store.get('incoming_channel')
     this._outgoingChannel = this._store.get('outgoing_channel')
     this._incomingClaim = JSON.parse(this._store.get('incoming_claim') || '{"amount":"0"}')
     this._outgoingClaim = JSON.parse(this._store.get('outgoing_claim') || '{"amount":"0"}')

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -157,6 +157,7 @@ describe('Plugin XRP Paychan Symmetric', function () {
     it('should handle ripple_channel_id protocol', async function () {
       // no need to look at the ledger in this test
       this.sinon.stub(this.plugin, '_reloadIncomingChannelDetails').callsFake(() => Promise.resolve())
+      const watchStub = this.sinon.stub(this.plugin._watcher, 'watch').callsFake(() => Promise.resolve())
       this.plugin._outgoingChannel = 'my_channel_id'
 
       const result = await this.plugin._handleData(null, {
@@ -171,11 +172,34 @@ describe('Plugin XRP Paychan Symmetric', function () {
       })
 
       assert.equal(this.plugin._incomingChannel, 'peer_channel_id', 'incoming channel should be set')
+      assert.isTrue(watchStub.called, 'should be watching channel')
       assert.deepEqual(result, [{
         protocolName: 'ripple_channel_id',
         contentType: BtpPacket.MIME_TEXT_PLAIN_UTF8,
         data: Buffer.from(this.plugin._outgoingChannel)
       }], 'result should contain outgoing channel')
+    })
+
+    it('should not reset existing channel with ripple_channel_id', async function () {
+      // no need to look at the ledger in this test
+      this.sinon.stub(this.plugin, '_reloadIncomingChannelDetails').callsFake(() => Promise.resolve())
+      const watchStub = this.sinon.stub(this.plugin._watcher, 'watch').callsFake(() => Promise.resolve())
+      this.plugin._incomingChannel = 'peer_channel_id'
+      this.plugin._outgoingChannel = 'my_channel_id'
+
+      await this.plugin._handleData(null, {
+        requestId: 1,
+        data: {
+          protocolData: [{
+            protocolName: 'ripple_channel_id',
+            contentType: BtpPacket.MIME_TEXT_PLAIN_UTF8,
+            data: Buffer.from('fake_peer_channel_id')
+          }]
+        }
+      })
+
+      assert.equal(this.plugin._incomingChannel, 'peer_channel_id', 'incoming channel should be set')
+      assert.isFalse(watchStub.called, 'should not be watching new channel')
     })
   })
 

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -156,11 +156,12 @@ describe('Plugin XRP Paychan Symmetric', function () {
 
     it('should handle ripple_channel_id protocol', async function () {
       // no need to look at the ledger in this test
+      this.getPaymentChannelStub = this.sinon.stub(this.plugin._api, 'getPaymentChannel').resolves(this.channel)
       this.sinon.stub(this.plugin, '_reloadIncomingChannelDetails').callsFake(() => Promise.resolve())
-      const watchStub = this.sinon.stub(this.plugin._watcher, 'watch').callsFake(() => Promise.resolve())
+      this.sinon.stub(this.plugin._watcher, 'watch').callsFake(() => Promise.resolve())
       this.plugin._outgoingChannel = 'my_channel_id'
 
-      const result = await this.plugin._handleData(null, {
+      await this.plugin._handleData(null, {
         requestId: 1,
         data: {
           protocolData: [{
@@ -170,36 +171,70 @@ describe('Plugin XRP Paychan Symmetric', function () {
           }]
         }
       })
-
-      assert.equal(this.plugin._incomingChannel, 'peer_channel_id', 'incoming channel should be set')
-      assert.isTrue(watchStub.called, 'should be watching channel')
-      assert.deepEqual(result, [{
-        protocolName: 'ripple_channel_id',
-        contentType: BtpPacket.MIME_TEXT_PLAIN_UTF8,
-        data: Buffer.from(this.plugin._outgoingChannel)
-      }], 'result should contain outgoing channel')
     })
 
-    it('should not reset existing channel with ripple_channel_id', async function () {
-      // no need to look at the ledger in this test
-      this.sinon.stub(this.plugin, '_reloadIncomingChannelDetails').callsFake(() => Promise.resolve())
-      const watchStub = this.sinon.stub(this.plugin._watcher, 'watch').callsFake(() => Promise.resolve())
-      this.plugin._incomingChannel = 'peer_channel_id'
-      this.plugin._outgoingChannel = 'my_channel_id'
-
-      await this.plugin._handleData(null, {
-        requestId: 1,
-        data: {
-          protocolData: [{
-            protocolName: 'ripple_channel_id',
-            contentType: BtpPacket.MIME_TEXT_PLAIN_UTF8,
-            data: Buffer.from('fake_peer_channel_id')
-          }]
+    describe('ripple_channel_id', function () {
+      beforeEach(function () {
+        this.getPaymentChannelStub = this.sinon.stub(this.plugin._api, 'getPaymentChannel').resolves()
+        this.sinon.stub(this.plugin, '_reloadIncomingChannelDetails').callsFake(() => Promise.resolve())
+        this.validateChannelDetailsStub = this.sinon.stub(this.plugin, '_validateChannelDetails').returns()
+        this.channelIdRequest = {
+          requestId: 1,
+          data: {
+            protocolData: [{
+              protocolName: 'ripple_channel_id',
+              contentType: BtpPacket.MIME_TEXT_PLAIN_UTF8,
+              data: Buffer.from('peer_channel_id')
+            }]
+          }
         }
+
+        // no need to look at the ledger in this test
+        this.watchStub = this.sinon.stub(this.plugin._watcher, 'watch').callsFake(() => Promise.resolve())
+        this.plugin._outgoingChannel = 'my_channel_id'
       })
 
-      assert.equal(this.plugin._incomingChannel, 'peer_channel_id', 'incoming channel should be set')
-      assert.isFalse(watchStub.called, 'should not be watching new channel')
+      it('should handle ripple_channel_id protocol', async function () {
+        const result = await this.plugin._handleData(null, this.channelIdRequest)
+
+        assert.equal(this.plugin._incomingChannel, 'peer_channel_id', 'incoming channel should be set')
+        assert.isTrue(this.watchStub.called, 'should be watching channel')
+        assert.deepEqual(result, [{
+          protocolName: 'ripple_channel_id',
+          contentType: BtpPacket.MIME_TEXT_PLAIN_UTF8,
+          data: Buffer.from(this.plugin._outgoingChannel)
+        }], 'result should contain outgoing channel')
+      })
+
+      it('should throw on invalid channel details', async function () {
+        // no need to look at the ledger in this test
+        this.validateChannelDetailsStub.throws()
+
+        await assert.isRejected(this.plugin._handleData(null, this.channelIdRequest), /Error/)
+        assert.equal(this.plugin._incomingChannel, null, 'incoming channel should not be set')
+      })
+
+      it('should not race two requests', async function () {
+        await Promise.all([
+          this.plugin._handleData(null, this.channelIdRequest),
+          this.plugin._handleData(null, this.channelIdRequest)
+        ])
+
+        assert.equal(this.validateChannelDetailsStub.callCount, 1,
+          'validate channel details should only be called once, otherwise there was a race')
+      })
+
+      it('should not reset existing channel with ripple_channel_id', async function () {
+        // no need to look at the ledger in this test
+        this.plugin._incomingChannel = 'peer_channel_id'
+        this.plugin._outgoingChannel = 'my_channel_id'
+
+        this.channelIdRequest.data.protocolData[0].data = Buffer.from('fake_peer_channel_id')
+        await this.plugin._handleData(null, this.channelIdRequest)
+
+        assert.equal(this.plugin._incomingChannel, 'peer_channel_id', 'incoming channel should be set')
+        assert.isFalse(this.watchStub.called, 'should not be watching new channel')
+      })
     })
   })
 


### PR DESCRIPTION
Won't reset channel ID if one already exists. Adds incoming channel ID to channel watcher.

Closes https://github.com/ripple/ilp-plugin-xrp-paychan/issues/33