### PR TITLE
Fix: load incoming channel details when incomingChannel comes from store

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ class PluginXrpPaychan extends PluginBtp {
         contentType: BtpPacket.MIME_TEXT_PLAIN_UTF8,
         data: Buffer.from(this._outgoingChannel || '')
       }]
-    } else if (!this._incomingChannel) {
+    } else if (!this._incomingChannel || !this._incomingChannelDetails) {
       await this._reloadIncomingChannelDetails()
     }
 
@@ -292,6 +292,7 @@ class PluginXrpPaychan extends PluginBtp {
 
     if (this._incomingChannel) {
       await this._watcher.watch(this._incomingChannel)
+      await this._reloadIncomingChannelDetails()
     }
 
     if (!this._outgoingChannel) {
@@ -404,7 +405,7 @@ class PluginXrpPaychan extends PluginBtp {
   async _handleMoney (from, { requestId, data }) {
     if (!this._connected) throw new Error('not connected')
 
-    if (!this._incomingChannel) {
+    if (!this._incomingChannelDetails || !this._incomingChannel) {
       await this._reloadIncomingChannelDetails()
     }
 

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -401,6 +401,17 @@ describe('Plugin XRP Paychan Symmetric', function () {
       assert.isTrue(this.loadStub.called, 'should have loaded outgoing channel')
     })
 
+    it('should load incoming channel details even if incoming channel already exists', async function () {
+      this.plugin._store.load('incoming_channel')
+      this.plugin._store.set('incoming_channel', this.channelId)
+      const spy = this.sinon.spy(this.plugin, '_reloadIncomingChannelDetails')
+
+      await this.plugin._connect()
+
+      assert.deepEqual(this.loadStub.firstCall.args, [ this.channelId ])
+      assert.isTrue(spy.calledOnce)
+    })
+
     it('should prepare a payment channel', async function () {
       await this.plugin._connect()
 


### PR DESCRIPTION
In the previous version, the payment channel details would never be loaded if they came from the store. Because all `reloadIncomingChannelDetails` calls were wrapped in `if (!this._incomingChannel)` they would never get called if the channel was loaded from the store.