### PR TITLE
Feat: only claim when profitable

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ class PluginXrpPaychan extends PluginBtp {
       }
     }
 
-    this._lastClaimedAmount = new BigNumber(util.xrpToDrops(this._incomingChannelDetails.balance))
+    this._lastClaimedAmount = new BigNumber(this.xrpToBase(this._incomingChannelDetails.balance))
     this._setupAutoClaim()
   }
 
@@ -232,9 +232,9 @@ class PluginXrpPaychan extends PluginBtp {
 
   async _isClaimProfitable () {
     const income = new BigNumber(this._incomingClaim.amount).minus(this._lastClaimedAmount)
-    const fee = new BigNumber(await this._api.getFee())
+    const fee = new BigNumber(this.xrpToBase(await this._api.getFee()))
 
-    return income.isGreaterThan(0) && fee.dividedBy(income).isLessThan(this._maxFeePercent)
+    return income.isGreaterThan(0) && fee.dividedBy(income).lte(this._maxFeePercent)
   }
 
   _setupAutoClaim () {


### PR DESCRIPTION
The plugin now has a `maxFeePercent` field. If it is issuing a claim, it will make sure that the ledger fee doesn't exceed that percent of the amount being claimed. If the `maxFeePercent` is `0.01`, for instance, a claim will only be issued if it brings in 100x or more of the ledger fee. This can be set via a constructor parameter, but is `0.01` by default.

Tests have been added to make sure that this feature works, including when the plugin's currencyScale exceeds the ledger scale.