### PR TITLE
Fix: funding

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const {
 // constants
 const CHANNEL_KEYS = 'ilp-plugin-xrp-paychan-channel-keys'
 const DEFAULT_CHANNEL_AMOUNT_XRP = 1
-const DEFAULT_FUND_THRESHOLD = 0.9
+const DEFAULT_FUND_THRESHOLD = 0.5
 
 class PluginXrpPaychan extends PluginBtp {
   constructor (opts) {

--- a/index.js
+++ b/index.js
@@ -346,6 +346,8 @@ class PluginXrpPaychan extends PluginBtp {
         break
       } catch (e) {
         if (e.name === 'TimeoutError') {
+          debug('timed out while loading outgoing channel details. retrying in 2s.' +
+            ' channel=' + this._outgoingChannel)
           await new Promise(resolve => setTimeout(resolve, 2000))
           continue
         } else {

--- a/index.js
+++ b/index.js
@@ -378,7 +378,7 @@ class PluginXrpPaychan extends PluginBtp {
       util.fundChannel({
         api: this._api,
         channel: this._outgoingChannel,
-        amount: util.xrpToDrops(this.baseToXrp(this._channelAmount)),
+        amount: util.xrpToDrops(this._outgoingChannelDetails.amount),
         address: this._address,
         secret: this._secret
       })


### PR DESCRIPTION
- Should improve the consistency of relationships between peers by reloading the channel details every time a fund is issued
- Should improve the efficiency of peering relationship during high throughput, by increasing channel capacity exponentially instead of linearly (doubles the capacity each time the channel is funded, instead of increasing by just 1 XRP)
- Adds tests to make sure that the funding logic works as expected