### PR TITLE
Fix: check channel amount signing outgoing claim

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -15,8 +15,16 @@ const xrpToDrops = (xrp) => new BigNumber(xrp).mul(DROPS_PER_XRP).toString()
 
 const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time))
 
+class MoneyNotSentError extends Error {
+  constructor (...args) {
+    super(...args)
+    this.name = 'MoneyNotSentError'
+  }
+}
+
 module.exports = {
   // helper functions
+  MoneyNotSentError,
   sleep,
   dropsToXrp,
   xrpToDrops,


### PR DESCRIPTION
When signing an outgoing claim, this checks the outgoing channel's capacity to make sure the claim is valid. If the claim will not be valid, it throws a `MoneyNotSentError`.

Currently the connector will apply a settlement to its balance and ignore if the `sendMoney` call fails. This issue should address that problem: https://github.com/interledgerjs/ilp-connector/issues/444